### PR TITLE
Display a 404 page if the repository is not found

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,9 @@
 class ApplicationController < ActionController::Base
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  rescue_from PullRequestFetcher::RepositoryNotFound do |_|
+    render file: Rails.root.join('/public/404.html'),
+           status: :not_found,
+           content_type: Mime::Type.lookup_by_extension(:html)
+  end
 end

--- a/app/services/pull_request_fetcher.rb
+++ b/app/services/pull_request_fetcher.rb
@@ -11,7 +11,9 @@ class PullRequestFetcher
   end
 
   def perform
-    if !response.empty?
+    if response.code == 404
+      raise RepositoryNotFound
+    elsif !response.empty?
       response
     else
       repository_response
@@ -32,5 +34,8 @@ class PullRequestFetcher
 
   def repository_response
     RepositoryFetcher.perform(owner: owner, repo: repo)
+  end
+
+  class RepositoryNotFound < StandardError
   end
 end

--- a/spec/fixtures/github/404.json
+++ b/spec/fixtures/github/404.json
@@ -1,0 +1,4 @@
+{
+  "message": "Not Found",
+  "documentation_url": "https://developer.github.com/v3"
+}

--- a/spec/requests/repository_not_found_requests_spec.rb
+++ b/spec/requests/repository_not_found_requests_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe 'Repository not found requests' do
+  describe 'GET non-existant repository' do
+    it 'renders a 404' do
+      stub_github_request
+
+      get feed_path(owner: 'foo', repo: 'bar')
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns a content type of html' do
+      stub_github_request
+
+      get feed_path(owner: 'foo', repo: 'bar')
+
+      expect(response.content_type).to eq(Mime::Type.lookup_by_extension(:html))
+    end
+  end
+
+  def stub_github_request
+    stub_request(:get, bad_url).
+      to_return(body: fixture_load('github', '404.json'),
+                headers: { 'Content-Type' => 'application/json' },
+                status: 404)
+  end
+
+  def bad_url
+    'https://api.github.com/repos/foo/bar/pulls'
+  end
+end

--- a/spec/services/pull_request_fetcher_spec.rb
+++ b/spec/services/pull_request_fetcher_spec.rb
@@ -59,6 +59,19 @@ describe PullRequestFetcher do
     end
   end
 
+  context "when a repository doesn't exist" do
+    it 'raises a not found error' do
+      stub_request(:get, bad_url).
+        to_return(body: fixture_load('github', '404.json'),
+                  headers: { 'Content-Type' => 'application/json' },
+                  status: 404)
+
+      expect {
+        PullRequestFetcher.perform(owner: 'foo', repo: 'bar')
+      }.to raise_error(PullRequestFetcher::RepositoryNotFound)
+    end
+  end
+
   def stub_github_response(url, response)
     stub_request(:get, url).
       to_return(body: response,
@@ -67,5 +80,9 @@ describe PullRequestFetcher do
 
   def github_url(owner:, repo:)
     "https://api.github.com/repos/#{owner}/#{repo}/pulls"
+  end
+
+  def bad_url
+    'https://api.github.com/repos/foo/bar/pulls'
   end
 end


### PR DESCRIPTION
For example, if a user visits pullfeed.co/feeds/foo/bar, it will just direct them to an html 404 page, not try to make a feed for them.