### PR TITLE
Add regex constraint to feeds path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
-  get 'feeds/:owner/:repo', to: 'feeds#show', as: :feed, defaults: { format: :atom }
+  get 'feeds/:owner/:repo',
+      to: 'feeds#show',
+      as: :feed,
+      constraints: { repo: /[^\/]+/ },
+      defaults: { format: :atom }
   get 'humans.txt', to: 'high_voltage/pages#show', id: 'humans'
 end

--- a/spec/routing/feeds_routing_spec.rb
+++ b/spec/routing/feeds_routing_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe 'feed routes' do
+  it 'routes repos with periods in their name' do
+    feed_route = {
+      format: :atom,
+      controller: 'feeds',
+      action: 'show',
+      owner: 'owner',
+      repo: 'com.repo'
+    }
+
+    expect(get('/feeds/owner/com.repo')).to route_to(feed_route)
+  end
+
+  it 'routes normal named repos' do
+    feed_route = {
+      format: :atom,
+      controller: 'feeds',
+      action: 'show',
+      owner: 'owner',
+      repo: 'repo'
+    }
+
+    expect(get('/feeds/owner/repo')).to route_to(feed_route)
+  end
+end


### PR DESCRIPTION
Most repository names are alphanumeric. `github/linguist`, `thoughtbot/paperclip`, etc. But repos can have periods in their names: `cocoaheadsboston/cocoaheadsboston.github.io`. This causes the router to think `.io` is a format, like `.rss` or `.json`. This commit adds a custom constraint to make repo match any character that isn't a slash `/`.