### PR TITLE
Add missing feed readers to the parser

### DIFF
--- a/app/services/subscription_parser.rb
+++ b/app/services/subscription_parser.rb
@@ -131,7 +131,12 @@ class SubscriptionParser
       'AppEngine-Googleappid' => 'Google App Engine',
       'Googlebot' => 'Googlebot',
       'UniversalFeedParser' => 'UniversalFeedParser',
-      'Opera' => 'Opera'
+      'Opera' => 'Opera',
+      'Feeds/' => 'Feeds App',
+      'Blogtrottr' => 'Blogtrottr',
+      'rawdog' => 'rawdog',
+      'com.apple.Safari.WebFeedParser' => 'Safari Built-in',
+      'spbot' => 'OpenLinkProfiler'
     }
   end
 end


### PR DESCRIPTION
This adds:

* [Feeds app](http://www.feedsapp.com)
* [Blogtrottr](http://blogtrottr.com)
* [rawdog](https://pypi.python.org/pypi/rawdog)
* Safari's Built-in RSS/Atom reader
* [OpenLinkProfiler's bot](http://openlinkprofiler.org/bot)